### PR TITLE
feat: semantic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ This repository contains a live coding exercise for building a GenAI powered not
     - scale
     - ⚠️ host model
 - retrieval
-    - make it work:
-        - what are the embeddings endpoints?
-        - what are the chat endpoints?
     - Return richer metadata (distance scores, highlight spans) to the chat layer.
     - Switch to cosine similarity if you normalize vectors—currently hard-coded L2.
     - nprobe fixed at 10; might need tuning or exposure as a parameter.
@@ -42,3 +39,4 @@ This repository contains a live coding exercise for building a GenAI powered not
 - agentic behaviour
     - ⚠️ MCP
     - tool selection
+- rename react components

--- a/src/licodex/api/routers/chat.py
+++ b/src/licodex/api/routers/chat.py
@@ -193,7 +193,8 @@ async def chat_send(
             if not note_obj or not getattr(note_obj, "content", None):
                 continue
             snippet = note_obj.content[:240].strip() or "(empty note)"
-            retrieved_pairs.append((nid, snippet, None))
+            distance = h.get("distance") if isinstance(h.get("distance"), (int, float)) else None
+            retrieved_pairs.append((nid, snippet, distance))
             seen_note_ids.add(nid)
             if len(retrieved_pairs) >= 3:  # limit sources attached to message
                 break
@@ -218,6 +219,29 @@ async def chat_send(
     last_user = payload.content or (history_user_texts[-1] if history_user_texts else "")
     settings = get_settings()
     resolved_model, reason = resolve_chat_model(payload.model)
+    # Build retrieval context (RAG augmentation) injected as a system message.
+    retrieval_context: str | None = None
+    if retrieved_pairs:
+        # Load system prompt from configured file path (caching contents in module-level singleton)
+        _sys_prompt: str | None = None
+        from licodex.core.config import get_settings as _gs
+        _p_settings = _gs()
+        import os
+        prompt_path = _p_settings.retrieval_system_prompt_path
+        # Resolve path relative to project root if necessary
+        if not os.path.isabs(prompt_path):
+            # Attempt to locate relative to current working dir
+            candidate = os.path.join(os.getcwd(), prompt_path)
+            prompt_path = candidate if os.path.exists(candidate) else prompt_path
+        with open(prompt_path, 'r', encoding='utf-8') as fh:  # noqa: PTH123
+            _sys_prompt = fh.read().strip()
+
+        lines: list[str] = []
+        for idx, (nid, quote, dist) in enumerate(retrieved_pairs, start=1):
+            dist_part = f" (dist={dist:.3f})" if isinstance(dist, (int, float)) else ""
+            lines.append(f"{idx}. note_id={nid}{dist_part} -> {quote}")
+        retrieval_context = (_sys_prompt + "\n\nRelevant notes:\n" + "\n".join(lines))
+
     if settings.modelhub_api_key and settings.modelhub_base_url:
         try:
             client = get_modelhub_client()
@@ -229,6 +253,9 @@ async def chat_send(
                     assembled.append({"role": "user", "content": pm.content})
                 if pm.response:
                     assembled.append({"role": "assistant", "content": pm.response})
+            # Inject retrieval context BEFORE current user question so model can ground answer.
+            if retrieval_context:
+                assembled.append({"role": "system", "content": retrieval_context})
             assembled.append({"role": "user", "content": payload.content})
             completion = client.chat.completions.create(
                 messages=assembled,

--- a/src/licodex/client/web/src/components/ChatPanel.tsx
+++ b/src/licodex/client/web/src/components/ChatPanel.tsx
@@ -108,7 +108,7 @@ export function ChatPanel({ licodex, selectedNote, selectedThreadId, onThreadDel
                         <button
                           className='btn tiny outline ml-4'
                           style={{ marginLeft: 8 }}
-                          title='Show sources'
+                          title={openSourcesFor === m.id ? 'Hide sources' : 'Show sources'}
                           onClick={() => void toggleSources(m)}
                         >
                           <Icon name='expand' size={12} />
@@ -125,7 +125,7 @@ export function ChatPanel({ licodex, selectedNote, selectedThreadId, onThreadDel
                           <div key={s.note_id} className='source-line'>
                             <span
                               className='source-note-id'
-                              title='Open note'
+                              title='Open note (click)'
                               onClick={() => onOpenNote?.(s.note_id)}
                             >
                               {s.note_id}

--- a/src/licodex/client/web/src/components/ChatPanel.tsx
+++ b/src/licodex/client/web/src/components/ChatPanel.tsx
@@ -20,6 +20,7 @@ export function ChatPanel({ licodex, selectedNote, selectedThreadId, onThreadDel
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const appendLocal = useCallback((line: ChatLine) => setLocalPending(h => [...h, line]), []);
   const [openSourcesFor, setOpenSourcesFor] = useState<string | null>(null);
+  const [dots, setDots] = useState('');
   const toggleSources = useCallback(async (m: Message) => {
     if (!m.source) return;
     if (openSourcesFor === m.id) { setOpenSourcesFor(null); return; }
@@ -36,10 +37,44 @@ export function ChatPanel({ licodex, selectedNote, selectedThreadId, onThreadDel
     appendLocal({ role: 'user', content: q, ts: Date.now() });
     setInput('');
     await licodex.sendChatMessage(selectedThreadId, q);
-    setTimeout(() => setLocalPending([]), 200);
   }, [appendLocal, input, licodex, selectedThreadId]);
 
   useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: 'smooth' }); });
+
+  // Determine if there is a pending assistant response (latest message without response)
+  const pendingMessage = (() => {
+    const msgs = licodex.messages.data?.filter(m => m.thread_id === selectedThreadId) || [];
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i];
+      if (!m.response || m.response.trim() === '') return m;
+    }
+    return null;
+  })();
+
+  // Animate thinking dots while pending
+  useEffect(() => {
+    if (pendingMessage) {
+      const id = setInterval(() => setDots(d => (d.length >= 3 ? '' : d + '.')), 400);
+      return () => clearInterval(id);
+    } else {
+      setDots('');
+    }
+  }, [pendingMessage]);
+
+  // Clear local pending lines when their persisted counterpart (with response) arrives
+  useEffect(() => {
+    if (!localPending.length) return;
+    const msgs = licodex.messages.data?.filter(m => m.thread_id === selectedThreadId) || [];
+    // If every local user line has a persisted message (regardless of response), drop optimistic copies
+    const allMatched = localPending.every(lp => msgs.some(m => m.content === lp.content));
+    if (allMatched) {
+      // Keep them until at least one matched message has a response to maintain waiting state
+      const anyResponded = msgs.some(m => localPending.some(lp => lp.content === m.content) && m.response && m.response.trim() !== '');
+      if (anyResponded) setLocalPending([]);
+    }
+  }, [licodex.messages.data, localPending, selectedThreadId]);
+
+  const waiting = localPending.length > 0 || !!pendingMessage;
 
   const thread = licodex.threads.data?.find(t => t.id === selectedThreadId);
 
@@ -150,17 +185,35 @@ export function ChatPanel({ licodex, selectedNote, selectedThreadId, onThreadDel
               </div>
             ))}
             {licodex.messages.loading && <div className="chat-line-bot fade-text">loading...</div>}
+            {/* Thinking animation for pending assistant response */}
+            {(waiting) && (
+              <div className='chat-line-bot thinking-line'>
+                licodex &gt; <span className='thinking-dots'>{dots}</span><span className='cursor-block' />
+              </div>
+            )}
+            {/* Inline prompt (terminal style) only when not waiting for assistant */}
+            {!waiting && (
+              <div className='chat-line-user prompt-line'>
+                <span>you &gt; </span>
+                <input
+                  className='prompt-input-inline'
+                  autoFocus
+                  value={input}
+                  placeholder=''
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey && selectedThreadId) { e.preventDefault(); void send(); } }}
+                />
+                <button
+                  className='btn outline inline-send'
+                  title='Send'
+                  onClick={() => void send()}
+                  disabled={!input.trim() || !selectedThreadId}
+                >
+                  <Icon name='send' size={ICON_SIZE} />
+                </button>
+              </div>
+            )}
             <div ref={bottomRef} />
-          </div>
-          <div className="chat-prompt">
-            <input
-              className="input prompt-input"
-              placeholder='Ask a question...'
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey && selectedThreadId) { e.preventDefault(); void send(); } }}
-            />
-            <button className="btn" title="Send" onClick={() => void send()} disabled={!input.trim() || !selectedThreadId}><Icon name="send" size={ICON_SIZE} /></button>
           </div>
         </>
       )}

--- a/src/licodex/client/web/src/theme.css
+++ b/src/licodex/client/web/src/theme.css
@@ -157,7 +157,7 @@ button { font-family: inherit; }
 
 /* Retrieval sources in chat */
 .source-line { padding:2px 0; display:flex; align-items:center; gap:6px; font-size:inherit; }
-.source-note-id { cursor:pointer; font-weight:600; }
+.source-note-id { cursor:pointer; font-weight:600; color:#ffcc00; }
 .source-note-id:hover { text-decoration: underline; }
 .distance-badge { background:#233028; border-color:#2d3a30; color:#7ee787; font-weight:500; }
 

--- a/src/licodex/client/web/src/theme.css
+++ b/src/licodex/client/web/src/theme.css
@@ -74,6 +74,17 @@ button { font-family: inherit; }
 .chat-line-bot { color: var(--text-primary); }
 .chat-prompt { border-top: 1px solid var(--border); padding: 8px 12px; display: flex; gap: 8px; }
 .prompt-input { flex: 1; }
+/* Inline terminal style prompt */
+.prompt-line { display:flex; align-items:center; gap:6px; margin-top:6px; }
+.prompt-input-inline { flex:1; background:transparent; border:none; color:var(--accent); font-family:inherit; font-size:inherit; padding:0; outline:none; }
+.prompt-input-inline:focus { outline:none; }
+.inline-send { visibility:hidden; }
+.prompt-input-inline:focus + .inline-send, .prompt-input-inline:not(:placeholder-shown) + .inline-send { visibility:visible; }
+/* Thinking animation */
+.thinking-line { color: var(--text-primary); }
+.thinking-dots { display:inline-block; min-width:24px; }
+@keyframes blinkCursor { 0%, 49% { opacity:1; } 50%, 100% { opacity:0; } }
+.cursor-block { display:inline-block; width:8px; height:14px; background:var(--accent); margin-left:2px; animation: blinkCursor 1s steps(2, start) infinite; vertical-align:text-bottom; }
 
 .note-list { overflow-y: auto; max-height: calc(100% - 48px); padding:0; margin:0; }
 .note-item { border: 1px solid var(--border); background: var(--bg-tertiary); padding: 6px 8px; border-radius: 0; cursor: pointer; display: flex; flex-direction: row; align-items:center; gap: 8px; position:relative; }

--- a/src/licodex/core/config.py
+++ b/src/licodex/core/config.py
@@ -120,6 +120,13 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("EMBEDDING_DEFAULT_DIM", "VECTOR_DIM", "EMBEDDINGS_DIM"),
         description="Default embedding vector dimension used when explicit collection config omits dim."
     )
+
+    # Path to retrieval augmentation system prompt (can be overridden via env)
+    retrieval_system_prompt_path: str = Field(
+        default="src/licodex/prompts/retrieval_system.txt",
+        validation_alias=AliasChoices("RETRIEVAL_SYSTEM_PROMPT_PATH"),
+        description="Filesystem path to system prompt injected before user message when retrieval context exists."
+    )
     model_config = SettingsConfigDict(env_file=".env", case_sensitive=False, extra="ignore")
 
     # Derived / convenience

--- a/src/licodex/prompts/retrieval_system.txt
+++ b/src/licodex/prompts/retrieval_system.txt
@@ -1,0 +1,6 @@
+You are an assistant with access to user-authored notes. Use ONLY the information in these notes to answer the user's next question.
+If the notes contain facts about a person or entity, state them confidently without mentioning training data or a knowledge cutoff.
+If a requested fact is absent, say you do not have that information in the provided notes.
+You will receive a list under the heading 'Relevant notes:' where each entry includes a note id and truncated content.
+Do not invent content not present in the notes.
+Keep answers concise unless the user explicitly asks for more detail.


### PR DESCRIPTION
- **feat: add milvus dependencies**
- **feat: add milvus component**
- **feat: add list collections router endpoint**
- **feat: add frontend quotes**
- **fix: remove network aliases, use container name**
- **feat: embeddings smoke test**
- **fix: no need for defaults**
- **fix: add db to network**
- **refactor: don't override embeddings params**
- **fix: smoke test**
- **feat: list all vectors endpoint**
- **fix: replace model name with model alias**
- **feat: embed notes on note save**
- **feat: embedding status to the right, context select to the left**
- **fix: delete embedding on note delete**
- **fix: delete embedding on note delete**
- **fix: flush to ensure vectors are queriable after new vector creation**
- **feat: semantic search**
- **feat: semantic search**
- **refactor: group id is sources id**
- **ignore: tsbuildinfo**
- **ignore: tsbuildinfo**
- **feat: use embeddings endpoint in chat router**
- **feat: alembic migration for response sources**
- **feat: untrack tsbuildinfo files**
- **feat: add distance badge to sources**
- **fix: change note field datatype to text (long responses/prompts)**
- **feat: semantic search**
- **chore: style chat as terminal**
